### PR TITLE
Setting insulin

### DIFF
--- a/InsulinNote_iOS/InsulinNote_iOS.xcodeproj/project.pbxproj
+++ b/InsulinNote_iOS/InsulinNote_iOS.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		25484BE42C91A8D9005119AC /* LongActingInsulinIsNotInjectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25484BE32C91A8D9005119AC /* LongActingInsulinIsNotInjectedView.swift */; };
 		25484BE52C91BB89005119AC /* InsulinSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252562412C4697CC00F7ECA1 /* InsulinSettingModel.swift */; };
 		25484BE62C91BB8A005119AC /* InsulinSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252562412C4697CC00F7ECA1 /* InsulinSettingModel.swift */; };
+		257730D32E3A618100AE651C /* EditInsulinSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257730D22E3A618100AE651C /* EditInsulinSettingView.swift */; };
+		2591518F2E38BD4F0092F7B7 /* SettingInsulinView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2591518E2E38BD4F0092F7B7 /* SettingInsulinView.swift */; };
 		25D2224B2DCBB52200DA1D90 /* RecordCalendarLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D2224A2DCBB52200DA1D90 /* RecordCalendarLogView.swift */; };
 		25D222502DDB620D00DA1D90 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D2224F2DDB620A00DA1D90 /* Date.swift */; };
 		25D5FEF32C7B3EB900DCC01C /* RecordingWidgetEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5FEF22C7B3E2700DCC01C /* RecordingWidgetEntryView.swift */; };
@@ -105,6 +107,8 @@
 		2543CB372D8AB4FB005BD9A2 /* RecordCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCalendarView.swift; sourceTree = "<group>"; };
 		25484BE12C91A4CD005119AC /* LongActingInsulinIsInjectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongActingInsulinIsInjectedView.swift; sourceTree = "<group>"; };
 		25484BE32C91A8D9005119AC /* LongActingInsulinIsNotInjectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongActingInsulinIsNotInjectedView.swift; sourceTree = "<group>"; };
+		257730D22E3A618100AE651C /* EditInsulinSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditInsulinSettingView.swift; sourceTree = "<group>"; };
+		2591518E2E38BD4F0092F7B7 /* SettingInsulinView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingInsulinView.swift; sourceTree = "<group>"; };
 		25D2224A2DCBB52200DA1D90 /* RecordCalendarLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCalendarLogView.swift; sourceTree = "<group>"; };
 		25D2224F2DDB620A00DA1D90 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		25D5FEF22C7B3E2700DCC01C /* RecordingWidgetEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingWidgetEntryView.swift; sourceTree = "<group>"; };
@@ -203,6 +207,7 @@
 		2525623E2C46954500F7ECA1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2591518D2E38BD360092F7B7 /* SettingInsulinView */,
 				2543CB352D8AB4D6005BD9A2 /* RecordCalendarView */,
 				2525622F2C4538F700F7ECA1 /* ContentView.swift */,
 				25FB36472C8F35B200BC0DA7 /* RecordView */,
@@ -244,6 +249,15 @@
 				25D2224A2DCBB52200DA1D90 /* RecordCalendarLogView.swift */,
 			);
 			path = RecordCalendarView;
+			sourceTree = "<group>";
+		};
+		2591518D2E38BD360092F7B7 /* SettingInsulinView */ = {
+			isa = PBXGroup;
+			children = (
+				2591518E2E38BD4F0092F7B7 /* SettingInsulinView.swift */,
+				257730D22E3A618100AE651C /* EditInsulinSettingView.swift */,
+			);
+			path = SettingInsulinView;
 			sourceTree = "<group>";
 		};
 		25D2224E2DDB61FE00DA1D90 /* Extensions */ = {
@@ -407,6 +421,7 @@
 			files = (
 				252562302C4538F700F7ECA1 /* ContentView.swift in Sources */,
 				25E53FC62C555027009DA024 /* NearDefaultDosageButton.swift in Sources */,
+				2591518F2E38BD4F0092F7B7 /* SettingInsulinView.swift in Sources */,
 				252993CD2C6F74EB0064C2F9 /* SoundPlayer.swift in Sources */,
 				25E53F292C4B9066009DA024 /* SetInsulinSettingView.swift in Sources */,
 				25484BE22C91A4CD005119AC /* LongActingInsulinIsInjectedView.swift in Sources */,
@@ -434,6 +449,7 @@
 				25E53F762C514DD8009DA024 /* insulinSettingAlertView.swift in Sources */,
 				25E53FC82C5550D4009DA024 /* DirectInputAdministrationView.swift in Sources */,
 				25E53F2D2C4FF0D3009DA024 /* InsulinSettingColumnView.swift in Sources */,
+				257730D32E3A618100AE651C /* EditInsulinSettingView.swift in Sources */,
 				25E53FC22C554F9B009DA024 /* InsulinNameView.swift in Sources */,
 				25FB36492C8F35E200BC0DA7 /* RecordView.swift in Sources */,
 				25D5FEF32C7B3EB900DCC01C /* RecordingWidgetEntryView.swift in Sources */,

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/ContentView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/ContentView.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
                           icon: { Image(systemName: "calendar") }
                     )
                 }
-            SetInsulinSettingView()
+            SettingInsulinView()
                 .tabItem {
                     Label(
                         title: { Text("setting") },

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/SettingInsulinView/EditInsulinSettingView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/SettingInsulinView/EditInsulinSettingView.swift
@@ -6,10 +6,15 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct EditInsulinSettingView: View {
     var insulinSetting: InsulinSettingModel?
     
+    @State private var isPresentingEditSheet = false
+    
+    @State private var productName = ""
+    @State private var dosage = "0"
     var body: some View {
         VStack(alignment: .leading){
             Text("\(insulinSetting?.actingType == .fast ? "속효성 인슐린" : "지효성 인슐린")")
@@ -21,20 +26,52 @@ struct EditInsulinSettingView: View {
                     Text("투여량: \(insulinSetting?.dosage ?? 0)")
                     Spacer()
                     Button {
-                        
+                        isPresentingEditSheet.toggle()
                     }label: {
                         Text("수정")
                             .frame(width: 50, height: 50)
                             .clipShape(Circle())
                             .overlay(
-                                Circle().stroke(Color.black, lineWidth: 1)
+                                Circle().stroke(Color.primary, lineWidth: 1)
                             )
                     }
                     Spacer()
                 }.font(.title2)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .border(.black, width: 1.0)
+            .border(.primary, width: 1.0)
+            .sheet(isPresented: $isPresentingEditSheet) {
+                Form {
+                    VStack{
+                        HStack(){
+                            Text("제품명")
+                            Divider()
+                            TextEditor(text: $productName)
+                        }
+                        HStack{
+                            Text("투여량")
+                            Divider()
+                            TextEditor(text: $dosage)
+                                .keyboardType(.numberPad)
+                        }
+                        Button{
+                            guard let dosage = Int(dosage) else  {
+                                print("정수가 아님")
+                                return
+                            }
+                            insulinSetting?.insulinProductName = productName
+                            insulinSetting?.dosage = dosage
+                            
+                            isPresentingEditSheet.toggle()
+                        }label: {
+                            Text("수정")
+                        }
+                    }
+                }.onAppear{
+                    productName = insulinSetting?.insulinProductName ?? ""
+                    dosage = String(insulinSetting?.dosage ?? 0)
+                }
+            }
         }
     }
 }

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/SettingInsulinView/EditInsulinSettingView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/SettingInsulinView/EditInsulinSettingView.swift
@@ -1,0 +1,51 @@
+//
+//  EditInsulinSettingView.swift
+//  InsulinNote_iOS
+//
+//  Created by 권희철 on 7/30/25.
+//
+
+import SwiftUI
+
+struct EditInsulinSettingView: View {
+    var insulinSetting: InsulinSettingModel?
+    
+    var body: some View {
+        VStack(alignment: .leading){
+            Text("\(insulinSetting?.actingType == .fast ? "속효성 인슐린" : "지효성 인슐린")")
+                .font(.title)
+            ZStack(alignment: .center){
+                VStack{
+                    Spacer()
+                    Text("\(insulinSetting?.insulinProductName ?? "설정되지 않은 인슐린")")
+                    Text("투여량: \(insulinSetting?.dosage ?? 0)")
+                    Spacer()
+                    Button {
+                        
+                    }label: {
+                        Text("수정")
+                            .frame(width: 50, height: 50)
+                            .clipShape(Circle())
+                            .overlay(
+                                Circle().stroke(Color.black, lineWidth: 1)
+                            )
+                    }
+                    Spacer()
+                }.font(.title2)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .border(.black, width: 1.0)
+        }
+    }
+}
+
+#Preview {
+    EditInsulinSettingView(
+        insulinSetting: InsulinSettingModel(
+            insulinProductName: "트레시바",
+            actingType: .long,
+            dosage: 20,
+            records: [],
+            updatedAt: .now)
+    )
+}

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/SettingInsulinView/SettingInsulinView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/SettingInsulinView/SettingInsulinView.swift
@@ -19,6 +19,7 @@ struct SettingInsulinView: View {
             EditInsulinSettingView(insulinSetting: insulinSettings.first(where: { $0.actingType == .fast}))
         }
         .padding(.horizontal, 10)
+        .padding(.bottom, 10)
     }
 }
 

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/SettingInsulinView/SettingInsulinView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/SettingInsulinView/SettingInsulinView.swift
@@ -1,0 +1,27 @@
+//
+//  SwiftUIView.swift
+//  InsulinNote_iOS
+//
+//  Created by 권희철 on 7/29/25.
+//
+
+import SwiftUI
+import SwiftData
+
+struct SettingInsulinView: View {
+    @Environment(\.modelContext) var insulinContext
+    @Query var insulinSettings: [InsulinSettingModel]
+    
+    
+    var body: some View {
+        VStack(alignment: .leading){
+            EditInsulinSettingView(insulinSetting: insulinSettings.first(where: { $0.actingType == .long}))
+            EditInsulinSettingView(insulinSetting: insulinSettings.first(where: { $0.actingType == .fast}))
+        }
+        .padding(.horizontal, 10)
+    }
+}
+
+#Preview {
+    SettingInsulinView()
+}


### PR DESCRIPTION
1. 지효성 인슐린, 속효성 인슐린의 제품명 및 투여량 설정하는 기능
2. 수정버튼을 눌렀을 때 시트를 올려서 수정

- 고민거리
1. 사용자가 사용하는 인슐린을 바꿔서 이름을 수정하는 경우 새로운 인슐린 세팅값을 만드는 것이 아니기 때문에 이전에 기록된 인슐린의 이름도 바뀜.
2. 사실 사용하는 인슐린 자체는 그렇게 중요하다고 생각하지 않는 앱이라 사용하던 인슐린들을 기록해야할지 말아야할지 고민 필요. 