### PR TITLE
Fix background refresh

### DIFF
--- a/InsulinNote_iOS/InsulinNote_iOS/Views/ContentView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/ContentView.swift
@@ -11,12 +11,17 @@ import SwiftData
 struct ContentView: View {
     
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.scenePhase) private var scenePhase
     @AppStorage("firstLaunched") var isLaunched: Bool = false
     @State private var firstSettingSheetPresented: Bool = false
     
+    //탭 변경 및 앱이 백그라운드에서 돌아올 때 시간을 갱신하기 위해서 사용
+    @State private var currentDate = Date()
+    @State private var selectedTab = 0
+    
     var body: some View {
-        TabView{
-            RecordView()
+        TabView(selection: $selectedTab) {
+            RecordView(date: currentDate)
                 .tabItem {
                     Label(
                         title: { Text("main") },
@@ -26,13 +31,15 @@ struct ContentView: View {
                 .sheet(isPresented: $firstSettingSheetPresented) {
                     FirstLunchView()
                 }
-            RecordCalendarView()
+                .tag(1)
+            RecordCalendarView(currentDate: currentDate)
                 .tabItem {
                     Label(
                         title: { Text("calendar") },
                           icon: { Image(systemName: "calendar") }
                     )
                 }.padding(.bottom, 10)
+                .tag(2)
             SettingInsulinView()
                 .tabItem {
                     Label(
@@ -40,6 +47,7 @@ struct ContentView: View {
                           icon: { Image(systemName: "gear") }
                     )
                 }.padding(.bottom, 10)
+                .tag(3)
         }.onAppear{
             if !isLaunched{
                 let longActionInsulin = InsulinSettingModel(insulinProductName: "지효성", actingType: .long, dosage: 20, records: [], updatedAt: .now)
@@ -51,6 +59,14 @@ struct ContentView: View {
                 firstSettingSheetPresented.toggle()
             }
             
+        }
+        .onChange(of: selectedTab) { oldValue, newValue in
+            currentDate = Date()
+        }
+        .onChange(of: scenePhase) { oldPhase, newPhase in
+            if newPhase == .active {
+                currentDate = Date()
+            }
         }
     }
 }

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/RecordCalendarView/RecordCalendarView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/RecordCalendarView/RecordCalendarView.swift
@@ -41,18 +41,19 @@ enum Weekday: Int, CaseIterable {
 struct RecordCalendarView: View {
     let gridItems = Array(repeating: GridItem(.flexible()), count: 7)
     
-    @State var isSheetPresented: Bool = false
-    @State var startDayOfWeek: Int = 0
-    @State var selectedYear: Int = 2025
-    @State var selectedMonth: Int = 4
+    @State private var isSheetPresented: Bool = false
+    @State private var startDayOfWeek: Int = 0
+    @State private var selectedYear: Int = 2025
+    @State private var selectedMonth: Int = 4
     
-    @State var selectedDate: Date? = nil
+    @State private var selectedDate: Date? = nil
     
-    var today: [Int]{
+    var currentDate: Date = Date()
+    private var today: [Int]{
         var dateElements: [Int] = []
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
-        let dateString = formatter.string(from: Date())
+        let dateString = formatter.string(from: currentDate)
         let dateArray = dateString.split(separator: "-")
         dateElements.append(Int(dateArray[0])!)
         dateElements.append(Int(dateArray[1])!)

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/RecordView/RecordView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/RecordView/RecordView.swift
@@ -42,7 +42,6 @@ struct RecordView:View {
     var body: some View {
         GeometryReader{proxy in
             VStack(alignment: .leading, spacing: 10){
-                Text("\(date)")
                 Text("\(selectedDate)")
                     .font(.largeTitle)
                 LongActingInsulinView(date: date,

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/RecordView/RecordView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/RecordView/RecordView.swift
@@ -42,6 +42,7 @@ struct RecordView:View {
     var body: some View {
         GeometryReader{proxy in
             VStack(alignment: .leading, spacing: 10){
+                Text("\(date)")
                 Text("\(selectedDate)")
                     .font(.largeTitle)
                 LongActingInsulinView(date: date,


### PR DESCRIPTION
앱이 실행중 인 경우 Date값이 변하지 않아서 백그라운드에 있다가 올라왔을 때 시간이 자정이 지나면 어제의 뷰가 계속 뜨는 문제가 있음.

실시간으로 타이머를 사용하여 Date 값을 바꾸는 것은 불필요 하다고 생각하여, 백그라운드에서 돌아올 때, 탭이 변경 될 때 Date값이 변동 되도록 수정함