### PR TITLE
날짜 관련 수정

### DIFF
--- a/InsulinNote_iOS/InsulinNote.xcodeproj/project.pbxproj
+++ b/InsulinNote_iOS/InsulinNote.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		253387412EF38E20004DAB06 /* ErrorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2533873F2EDF0654004DAB06 /* ErrorManager.swift */; };
 		253387432EF94310004DAB06 /* UserDefaults + shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253387422EF94302004DAB06 /* UserDefaults + shared.swift */; };
 		253387442EF9437E004DAB06 /* UserDefaults + shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253387422EF94302004DAB06 /* UserDefaults + shared.swift */; };
+		253387462F042EA1004DAB06 /* DateFormatter + format.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253387452F042E8E004DAB06 /* DateFormatter + format.swift */; };
+		253387472F042EA1004DAB06 /* DateFormatter + format.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253387452F042E8E004DAB06 /* DateFormatter + format.swift */; };
+		253387492F042EFC004DAB06 /* FormatStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253387482F042EF3004DAB06 /* FormatStyles.swift */; };
 		2543CB382D8AB4FB005BD9A2 /* RecordCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2543CB372D8AB4FB005BD9A2 /* RecordCalendarView.swift */; };
 		25484BE22C91A4CD005119AC /* LongActingInsulinIsInjectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25484BE12C91A4CD005119AC /* LongActingInsulinIsInjectedView.swift */; };
 		25484BE42C91A8D9005119AC /* LongActingInsulinIsNotInjectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25484BE32C91A8D9005119AC /* LongActingInsulinIsNotInjectedView.swift */; };
@@ -57,7 +60,7 @@
 		2561258C2E4B0F53003CA709 /* RecordDetailSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2561258B2E4B0F45003CA709 /* RecordDetailSheetView.swift */; };
 		257730D32E3A618100AE651C /* EditInsulinSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257730D22E3A618100AE651C /* EditInsulinSettingView.swift */; };
 		2591518F2E38BD4F0092F7B7 /* SettingInsulinView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2591518E2E38BD4F0092F7B7 /* SettingInsulinView.swift */; };
-		25D222502DDB620D00DA1D90 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D2224F2DDB620A00DA1D90 /* Date.swift */; };
+		25D222502DDB620D00DA1D90 /* Date + id.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D2224F2DDB620A00DA1D90 /* Date + id.swift */; };
 		25D5FEF32C7B3EB900DCC01C /* RecordingWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5FEF22C7B3E2700DCC01C /* RecordingWidgetView.swift */; };
 		25D5FEF42C7B3EBA00DCC01C /* RecordingWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5FEF22C7B3E2700DCC01C /* RecordingWidgetView.swift */; };
 		25E53FF72C5E3AD2009DA024 /* HowManyGetProductView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E53FF62C5E3AD2009DA024 /* HowManyGetProductView.swift */; };
@@ -114,6 +117,8 @@
 		252993CF2C6F75090064C2F9 /* intent-click-sound.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "intent-click-sound.mp3"; sourceTree = "<group>"; };
 		2533873F2EDF0654004DAB06 /* ErrorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorManager.swift; sourceTree = "<group>"; };
 		253387422EF94302004DAB06 /* UserDefaults + shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults + shared.swift"; sourceTree = "<group>"; };
+		253387452F042E8E004DAB06 /* DateFormatter + format.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter + format.swift"; sourceTree = "<group>"; };
+		253387482F042EF3004DAB06 /* FormatStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatStyles.swift; sourceTree = "<group>"; };
 		2543CB372D8AB4FB005BD9A2 /* RecordCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCalendarView.swift; sourceTree = "<group>"; };
 		25484BE12C91A4CD005119AC /* LongActingInsulinIsInjectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongActingInsulinIsInjectedView.swift; sourceTree = "<group>"; };
 		25484BE32C91A8D9005119AC /* LongActingInsulinIsNotInjectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongActingInsulinIsNotInjectedView.swift; sourceTree = "<group>"; };
@@ -129,7 +134,7 @@
 		2561258B2E4B0F45003CA709 /* RecordDetailSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordDetailSheetView.swift; sourceTree = "<group>"; };
 		257730D22E3A618100AE651C /* EditInsulinSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditInsulinSettingView.swift; sourceTree = "<group>"; };
 		2591518E2E38BD4F0092F7B7 /* SettingInsulinView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingInsulinView.swift; sourceTree = "<group>"; };
-		25D2224F2DDB620A00DA1D90 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		25D2224F2DDB620A00DA1D90 /* Date + id.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date + id.swift"; sourceTree = "<group>"; };
 		25D5FEF22C7B3E2700DCC01C /* RecordingWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingWidgetView.swift; sourceTree = "<group>"; };
 		25E53FF62C5E3AD2009DA024 /* HowManyGetProductView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HowManyGetProductView.swift; sourceTree = "<group>"; };
 		25FB36482C8F35E200BC0DA7 /* RecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordView.swift; sourceTree = "<group>"; };
@@ -201,6 +206,7 @@
 		2525622C2C4538F700F7ECA1 /* InsulinNote_iOS */ = {
 			isa = PBXGroup;
 			children = (
+				253387482F042EF3004DAB06 /* FormatStyles.swift */,
 				2533873F2EDF0654004DAB06 /* ErrorManager.swift */,
 				256022A92ED97E04006CF8D5 /* ModelError.swift */,
 				25D2224E2DDB61FE00DA1D90 /* Extensions */,
@@ -319,8 +325,9 @@
 		25D2224E2DDB61FE00DA1D90 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				253387452F042E8E004DAB06 /* DateFormatter + format.swift */,
 				253387422EF94302004DAB06 /* UserDefaults + shared.swift */,
-				25D2224F2DDB620A00DA1D90 /* Date.swift */,
+				25D2224F2DDB620A00DA1D90 /* Date + id.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -449,6 +456,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				252562302C4538F700F7ECA1 /* ContentView.swift in Sources */,
+				253387492F042EFC004DAB06 /* FormatStyles.swift in Sources */,
 				253387432EF94310004DAB06 /* UserDefaults + shared.swift in Sources */,
 				2560226F2E8387F2006CF8D5 /* SettingInitView.swift in Sources */,
 				2591518F2E38BD4F0092F7B7 /* SettingInsulinView.swift in Sources */,
@@ -470,13 +478,14 @@
 				25484BE42C91A8D9005119AC /* LongActingInsulinIsNotInjectedView.swift in Sources */,
 				256022722E851B89006CF8D5 /* WidgetExplainView.swift in Sources */,
 				2525622E2C4538F700F7ECA1 /* InsulinNote_iOSApp.swift in Sources */,
-				25D222502DDB620D00DA1D90 /* Date.swift in Sources */,
+				25D222502DDB620D00DA1D90 /* Date + id.swift in Sources */,
 				252562402C46956400F7ECA1 /* InsulinRecordModel.swift in Sources */,
 				252993CA2C6F70C00064C2F9 /* RecordingIntent.swift in Sources */,
 				256022AA2ED97E20006CF8D5 /* ModelError.swift in Sources */,
 				256022A72EBD01D8006CF8D5 /* InsulinSettingQuery.swift in Sources */,
 				257730D32E3A618100AE651C /* EditInsulinSettingView.swift in Sources */,
 				2561258C2E4B0F53003CA709 /* RecordDetailSheetView.swift in Sources */,
+				253387472F042EA1004DAB06 /* DateFormatter + format.swift in Sources */,
 				25FB36492C8F35E200BC0DA7 /* RecordView.swift in Sources */,
 				25D5FEF32C7B3EB900DCC01C /* RecordingWidgetView.swift in Sources */,
 			);
@@ -489,6 +498,7 @@
 				2560226B2E83876E006CF8D5 /* FirstLunchView.swift in Sources */,
 				253387412EF38E20004DAB06 /* ErrorManager.swift in Sources */,
 				256022642E7B1654006CF8D5 /* LockScreenInfoView.swift in Sources */,
+				253387462F042EA1004DAB06 /* DateFormatter + format.swift in Sources */,
 				252993C82C6F6C5E0064C2F9 /* InsulinRecordModel.swift in Sources */,
 				25D5FEF42C7B3EBA00DCC01C /* RecordingWidgetView.swift in Sources */,
 				256022A22EB7A001006CF8D5 /* ModelContextStore.swift in Sources */,

--- a/InsulinNote_iOS/InsulinNote_iOS/Extensions/DateFormatter + format.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Extensions/DateFormatter + format.swift
@@ -1,0 +1,45 @@
+//
+//  DateFormatter + format.swift
+//  InsulinNote
+//
+//  Created by 권희철 on 12/31/25.
+//
+
+import Foundation
+
+extension DateFormatter {
+    static let yyyyMMdd: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    static let hourMinute: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    static let fullDateKorean: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일 E"
+        return formatter
+    }()
+
+    static let doseTimeKorean: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "a h시 mm분"
+        return formatter
+    }()
+
+    static let yyyyMMddHHmmss: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+}

--- a/InsulinNote_iOS/InsulinNote_iOS/FormatStyles.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/FormatStyles.swift
@@ -1,0 +1,34 @@
+//
+//  FormatStyles.swift
+//  InsulinNote
+//
+//  Created by 권희철 on 12/31/25.
+//
+
+import Foundation
+
+struct DateFormat {
+    let dateWeekday = Date.FormatStyle()
+        .year()
+        .month()
+        .day()
+        .weekday()
+        .locale(Locale(identifier: "ko_KR"))
+    
+    let date = Date.FormatStyle()
+        .year()
+        .month()
+        .day()
+        .locale(Locale(identifier: "ko_KR"))
+    
+    let yearMonth = Date.FormatStyle()
+        .year()
+        .month()
+        .locale(Locale(identifier: "ko_KR"))
+    
+    let time = Date.FormatStyle()
+        .hour(.twoDigits(amPM: .wide))
+        .minute()
+        .locale(Locale(identifier: "ko_KR"))
+        
+}

--- a/InsulinNote_iOS/InsulinNote_iOS/Models/InsulinRecordModel.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Models/InsulinRecordModel.swift
@@ -19,15 +19,11 @@ final public class InsulinRecordModel: Identifiable{
     var updatedAt: Date //변경시간
     
     var dateString: String{
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: createdAt)
+        DateFormatter.yyyyMMdd.string(from: createdAt)
     }
     
     var timeString: String{
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter.string(from: createdAt)
+        DateFormatter.hourMinute.string(from: createdAt)
     }
     
     var setting: InsulinSettingModel?

--- a/InsulinNote_iOS/InsulinNote_iOS/Models/InsulinSettingModel.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Models/InsulinSettingModel.swift
@@ -24,8 +24,6 @@ final public class InsulinSettingModel: Identifiable, AppEntity, Sendable {
     var updatedAt: Date //변경시간
     
     init(insulinProductName: String, actingType: ActingType, dosage: Int, records: [InsulinRecordModel], updatedAt: Date) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm a"
         self.insulinProductName = insulinProductName
         self.actingType = actingType
         self.dosage = dosage

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/RecordCalendarView/RecordCalendarView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/RecordCalendarView/RecordCalendarView.swift
@@ -51,9 +51,7 @@ struct RecordCalendarView: View {
     var currentDate: Date = Date()
     private var today: [Int]{
         var dateElements: [Int] = []
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        let dateString = formatter.string(from: currentDate)
+        let dateString = DateFormatter.yyyyMMdd.string(from: currentDate)
         let dateArray = dateString.split(separator: "-")
         dateElements.append(Int(dateArray[0])!)
         dateElements.append(Int(dateArray[1])!)
@@ -62,7 +60,6 @@ struct RecordCalendarView: View {
     }
     
     @Environment(\.modelContext) var insulinContext
-    @Query var records: [InsulinRecordModel]
     
     var body: some View {
         VStack{
@@ -90,42 +87,14 @@ struct RecordCalendarView: View {
                     Image(systemName: "chevron.right")
                 }
             }
-            LazyVGrid(columns: gridItems) {
-                ForEach(Weekday.allCases, id: \.self){ dow in
-                    Text("\(dow.getString())")
-                }
-                ForEach(1..<(startDayOfWeek + getLastDayOfMonth(selectedYear, selectedMonth)!), id: \.self){ item in
-                    let day = item - startDayOfWeek + 1
-                    if item >= startDayOfWeek{
-                        ZStack{
-                            if selectedYear == today[0] && selectedYear == today[0] && selectedMonth == today[1] && (day) == today[2]{ //오늘이 맞는지
-                                Circle().fill(.yellow).opacity(0.3).frame(maxWidth: 30, maxHeight: 30)
-                            }
-                            if getIsInjected(year: selectedYear, month: selectedMonth, day: (day)){
-                                Circle().stroke(
-                                    Color.green,
-                                    style: StrokeStyle(lineWidth: 1.0 ))
-                                .frame(maxWidth: 30, maxHeight: 30)
-                            }
-                            if selectedYear < today[0] || selectedMonth < today[1] || day <= today[2] {
-                                Text("\(day)").frame(maxWidth: 40, maxHeight: 40)
-                                    .onTapGesture {
-                                        if selectedYear == today[0] && selectedMonth == today[1] && day == today[2]{
-                                            selectedDate = .now
-                                        }else{
-                                            selectedDate = intToDate(year: selectedYear, month: selectedMonth, day: day)
-                                        }
-                                    }
-                            }else{
-                                Text("\(day)").frame(maxWidth: 40, maxHeight: 40)
-                            }
-                            
-                        }
-                    }else{
-                        Text("")
-                    }
-                }
-            }
+            MonthlyRecordGridView(
+                gridItems: gridItems,
+                startDayOfWeek: startDayOfWeek,
+                selectedYear: selectedYear,
+                selectedMonth: selectedMonth,
+                today: today,
+                selectedDate: $selectedDate
+            )
         }.onAppear{
             selectedYear = today[0]
             selectedMonth = today[1]
@@ -147,33 +116,138 @@ struct RecordCalendarView: View {
     //월의 마지막날을 찾는 함수
     func getLastDayOfMonth(_ year:Int, _ month: Int) -> Int?{
         let calendar = Calendar.current
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        let startDay = formatter.date(from: "\(year)-\(month)-01")!
+        let startDay = DateFormatter.yyyyMMdd.date(from: "\(year)-\(month)-01")!
         let nextStartDay = calendar.date(byAdding: .month, value: 1, to: startDay)!
         let end = calendar.dateComponents([.day], from: startDay, to:nextStartDay)
         
         guard let day = end.day else { return nil }
         return day
     }
-    //해당 날짜에 투여 기록이 있는지 반환 있으면 true 없으면 false
-    func getIsInjected(year:Int, month: Int, day: Int) -> Bool{
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        let checkDate = "\(year)-\(String(format: "%02d", month))-\(String(format: "%02d", day))"
-        let injectedRecords = records.filter{
-            let createdDate = formatter.string(from: $0.createdAt)
-            return createdDate == checkDate && $0.setting?.actingType == .long //해당 날짜에 투여한 기록이고 지효성인 경우 반환
-        }
-        
-        return !injectedRecords.isEmpty
-    }
     
     func intToDate(year: Int, month: Int, day: Int) -> Date{
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         let dateString = "\(year)-\(String(format: "%02d", month))-\(String(format: "%02d", day)) 23:59:59"
-        return formatter.date(from: dateString) ?? Date()
+        return DateFormatter.yyyyMMddHHmmss.date(from: dateString) ?? Date()
+    }
+}
+
+private struct MonthlyRecordGridView: View {
+    let gridItems: [GridItem]
+    let startDayOfWeek: Int
+    let selectedYear: Int
+    let selectedMonth: Int
+    let today: [Int]
+    @Binding var selectedDate: Date?
+
+    @Query private var records: [InsulinRecordModel]
+
+    init(
+        gridItems: [GridItem],
+        startDayOfWeek: Int,
+        selectedYear: Int,
+        selectedMonth: Int,
+        today: [Int],
+        selectedDate: Binding<Date?>
+    ) {
+        self.gridItems = gridItems
+        self.startDayOfWeek = startDayOfWeek
+        self.selectedYear = selectedYear
+        self.selectedMonth = selectedMonth
+        self.today = today
+        _selectedDate = selectedDate
+
+        let calendar = Calendar.current
+        let monthStart = calendar.date(from: DateComponents(year: selectedYear, month: selectedMonth, day: 1)) ?? .now
+        let nextMonthStart = calendar.date(byAdding: .month, value: 1, to: monthStart) ?? monthStart.addingTimeInterval(86400 * 31)
+
+        _records = Query(
+            filter: #Predicate<InsulinRecordModel> { record in
+                record.createdAt >= monthStart && record.createdAt < nextMonthStart
+            }
+        )
+    }
+
+    private var injectedLongDays: Set<Int> {
+        let calendar = Calendar.current
+        var set = Set<Int>()
+        for record in records {
+            guard record.setting?.actingType == .long else { continue }
+            let day = calendar.component(.day, from: record.createdAt)
+            set.insert(day)
+        }
+        return set
+    }
+
+    var body: some View {
+        LazyVGrid(columns: gridItems) {
+            ForEach(Weekday.allCases, id: \.self) { dow in
+                Text("\(dow.getString())")
+            }
+
+            let lastDay = getLastDayOfMonth(selectedYear, selectedMonth) ?? 30
+            ForEach(1..<(startDayOfWeek + lastDay), id: \.self) { item in
+                let day = item - startDayOfWeek + 1
+
+                if item >= startDayOfWeek {
+                    ZStack {
+                        if selectedYear == today[0] && selectedMonth == today[1] && day == today[2] { // 오늘
+                            Circle()
+                                .fill(.yellow)
+                                .opacity(0.3)
+                                .frame(maxWidth: 30, maxHeight: 30)
+                        }
+
+                        if injectedLongDays.contains(day) {
+                            Circle()
+                                .stroke(
+                                    Color.green,
+                                    style: StrokeStyle(lineWidth: 1.0)
+                                )
+                                .frame(maxWidth: 30, maxHeight: 30)
+                        }
+
+                        if isDayTappable(year: selectedYear, month: selectedMonth, day: day) {
+                            Text("\(day)")
+                                .frame(maxWidth: 40, maxHeight: 45)
+                                .onTapGesture {
+                                    selectedDate = intToDate(year: selectedYear, month: selectedMonth, day: day)
+                                }
+                        } else {
+                            Text("\(day)").frame(maxWidth: 40, maxHeight: 45)
+                        }
+                    }
+                } else {
+                    Text("")
+                }
+            }
+        }
+    }
+
+    // 월의 마지막날을 찾는 함수
+    private func getLastDayOfMonth(_ year: Int, _ month: Int) -> Int? {
+        let calendar = Calendar.current
+        let startDay = DateFormatter.yyyyMMdd.date(from: "\(year)-\(month)-01")!
+        let nextStartDay = calendar.date(byAdding: .month, value: 1, to: startDay)!
+        let end = calendar.dateComponents([.day], from: startDay, to: nextStartDay)
+
+        guard let day = end.day else { return nil }
+        return day
+    }
+
+    private func intToDate(year: Int, month: Int, day: Int) -> Date {
+        let dateString = "\(year)-\(String(format: "%02d", month))-\(String(format: "%02d", day)) 23:59:59"
+        return DateFormatter.yyyyMMddHHmmss.date(from: dateString) ?? Date()
+    }
+
+    /// 오늘(포함) 이후·미래 월은 탭 불가. 과거 일만 RecordView로 연다.
+    private func isDayTappable(year: Int, month: Int, day: Int) -> Bool {
+        let calendar = Calendar.current
+        guard
+            let cellDate = calendar.date(from: DateComponents(year: year, month: month, day: day)),
+            let todayDate = calendar.date(from: DateComponents(year: today[0], month: today[1], day: today[2]))
+        else { return false }
+        let cellStart = calendar.startOfDay(for: cellDate)
+        let todayStart = calendar.startOfDay(for: todayDate)
+        return cellStart < todayStart
     }
 }
 

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/RecordView/LongActingInsulin/LongActingInsulinIsInjectedView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/RecordView/LongActingInsulin/LongActingInsulinIsInjectedView.swift
@@ -13,11 +13,8 @@ struct LongActingInsulinIsInjectedView:View {
     let proxy: GeometryProxy
     
     var injectedDate: String {
-        let formatter = DateFormatter()
-        formatter.locale = .init(identifier: "ko_KR")
-        formatter.dateFormat = "a h시 mm분"
         if let insulinRecord{
-            return formatter.string(from: insulinRecord.createdAt)
+            return DateFormatter.doseTimeKorean.string(from: insulinRecord.createdAt)
         }else{
             return "없음"
         }

--- a/InsulinNote_iOS/InsulinNote_iOS/Views/RecordView/RecordView.swift
+++ b/InsulinNote_iOS/InsulinNote_iOS/Views/RecordView/RecordView.swift
@@ -33,10 +33,7 @@ struct RecordView: View {
     }
 
     var selectedDate: String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_kr")
-        formatter.dateFormat = "yyyy년 M월 d일 E"
-        return formatter.string(from: date)
+        DateFormatter.fullDateKorean.string(from: date)
     }
 
     var body: some View {
@@ -86,3 +83,4 @@ struct RecordView: View {
         }
     }
 }
+

--- a/InsulinNote_iOS/RecordingWidget/LockScreenInfoWidget/LockScreenInfoView.swift
+++ b/InsulinNote_iOS/RecordingWidget/LockScreenInfoWidget/LockScreenInfoView.swift
@@ -11,11 +11,6 @@ import SwiftUI
 struct LockScreenInfoView: View {
 
     var entry: LastDoseEntry
-    let formatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter
-    }()
 
     var body: some View {
         VStack {
@@ -23,7 +18,7 @@ struct LockScreenInfoView: View {
                 Text("\(entry.longActingName)")
                 Spacer()
                 Text(
-                    "\(formatter.string(for: entry.longActingLastDoseInToday) ?? "기록 없음")"
+                    "\(DateFormatter.hourMinute.string(for: entry.longActingLastDoseInToday) ?? "기록 없음")"
                 )
 
             }
@@ -31,7 +26,7 @@ struct LockScreenInfoView: View {
                 Text("\(entry.FastActingName)")
                 Spacer()
                 Text(
-                    "\(formatter.string(for: entry.fastActingLastDoseInToday) ?? "기록 없음")"
+                    "\(DateFormatter.hourMinute.string(for: entry.fastActingLastDoseInToday) ?? "기록 없음")"
                 )
             }
         }

--- a/InsulinNote_iOS/RecordingWidget/RecordingWidget/RecordingWidgetView.swift
+++ b/InsulinNote_iOS/RecordingWidget/RecordingWidget/RecordingWidgetView.swift
@@ -13,12 +13,6 @@ struct RecordingWidgetView: View {
     var entry: RecordingEntry
     @Environment(\.widgetFamily) var family
 
-    let formatter: DateFormatter = {  //리턴할 때 사용
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter
-    }()
-
     var body: some View {
         ZStack{
             
@@ -54,7 +48,7 @@ struct RecordingWidgetView: View {
                             Text("\(entry.dosage)단위")
                             if let lastRecordDate = entry.lastRecordDate {
                                 Text(
-                                    "\(formatter.string(from: lastRecordDate)) 투여됨"
+                                    "\(DateFormatter.hourMinute.string(from: lastRecordDate)) 투여됨"
                                 )
                             } else {
                                 Toggle(
@@ -73,7 +67,7 @@ struct RecordingWidgetView: View {
                                 .font(.largeTitle)
                             Text("\(entry.dosage)단위")
                             if let lastRecordDate = entry.lastRecordDate{
-                                Text("\(formatter.string(from: lastRecordDate))")
+                                Text("\(DateFormatter.hourMinute.string(from: lastRecordDate))")
                             }
                             Button(
                                 intent: RecordingIntent(id: entry.settingId)
@@ -110,14 +104,11 @@ struct RecordingWidgetView: View {
     }
 
     private func getIsInjected(records: [InsulinRecordModel]) -> Bool {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy-MM-dd"
         let today = Date()
-        let strToday = formatter.string(from: today)
+        let strToday = DateFormatter.yyyyMMdd.string(from: today)
 
         let record = records.filter {
-            return formatter.string(from: $0.createdAt) == strToday
+            return DateFormatter.yyyyMMdd.string(from: $0.createdAt) == strToday
         }.sorted(by: { $0.createdAt > $1.createdAt })
 
         if record.isEmpty { return false } else { return true }
@@ -125,18 +116,13 @@ struct RecordingWidgetView: View {
 
     private func getLastInjected(records: [InsulinRecordModel]) -> String {
         let calendar = Calendar.current
-        let timeFormmatter: DateFormatter = {  //리턴할 때 사용
-            let formatter = DateFormatter()
-            formatter.dateFormat = "HH:mm"
-            return formatter
-        }()
 
         let lastInjectedRecord = records.filter {
             calendar.isDateInToday($0.createdAt)
         }.sorted { $0.createdAt > $1.createdAt }
 
         if let record = lastInjectedRecord.first {
-            return timeFormmatter.string(from: record.createdAt)
+            return DateFormatter.hourMinute.string(from: record.createdAt)
         } else {
             return "오늘 기록 없음"
         }


### PR DESCRIPTION
1. DateFormatter 확장으로 포맷을 미리 정의해두고 사용
2. DateFormatter의 포맷을 스태틱으로 불러서 DateFormatter를 여러번 호출하지 않게 수정
3. CalendarView에서 현재 보고있는 달의 정보만 불러오도록 쿼리 수정
4. CalendarView에서 현재 날짜 이후는 선택하지 못하도록 수정